### PR TITLE
Revert "input: vl53l0: Report SPAD count as ABS_BRAKE instead of ABS_…

### DIFF
--- a/drivers/input/misc/vl53L0/stmvl53l0_module.c
+++ b/drivers/input/misc/vl53L0/stmvl53l0_module.c
@@ -771,7 +771,7 @@ static void stmvl53l0_ps_read_measurement(struct stmvl53l0_data *data)
 		input_report_abs(data->input_dev_ps, ABS_WHEEL,
 				LimitCheckCurrent);
 	}
-	input_report_abs(data->input_dev_ps, ABS_BRAKE,
+	input_report_abs(data->input_dev_ps, ABS_PRESSURE,
 		data->rangeData.EffectiveSpadRtnCount);
 	input_sync(data->input_dev_ps);
 
@@ -2188,7 +2188,7 @@ int stmvl53l0_setup(struct stmvl53l0_data *data)
 	input_set_abs_params(data->input_dev_ps, ABS_HAT3Y, 0, 0xffffffff,
 		0, 0);
 
-	input_set_abs_params(data->input_dev_ps, ABS_BRAKE, 0, 0xffffffff,
+	input_set_abs_params(data->input_dev_ps, ABS_PRESSURE, 0, 0xffffffff,
 		0, 0);
 
 	input_set_abs_params(data->input_dev_ps, ABS_WHEEL , 0, 0xffffffff,


### PR DESCRIPTION
…PRESSURE"

* This is superceded by adding excluded-input-devices in the device tree

This reverts commit e4a15d55e37c667f673375b69487a7da16f0e068.